### PR TITLE
Fix a deadlock in ALSA plugin

### DIFF
--- a/src/audio/plugins/alsa.cpp
+++ b/src/audio/plugins/alsa.cpp
@@ -188,7 +188,7 @@ Stream *AlsaPlugin::open(const DeviceInfo::Id &id, const Plugin::Direction &mode
             m_devices[ {mode, id}] = nullptr;
             device->deleteLater();
             m_deviceListMutex.unlock();
-        });
+        }, Qt::DirectConnection);
 
         m_devices[ {mode, id}] = device;
     }

--- a/src/generator/musicnoise.cpp
+++ b/src/generator/musicnoise.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "musicnoise.h"
+#include <math.h>
 
 MusicNoise::MusicNoise(QObject *parent) : OutputDevice(parent)
 {


### PR DESCRIPTION
When switching audio device on Linux with ALSA plugin, a deadlock in AlsaPlugin::open often occurs. `m_deviceListMutex` is supposed to be released after emitting `AlsaPCMDevice::closed` signal, but a connected slot is often not called.

As the signal is emitted from a different thread than a receiver is living, `Qt::QueuedConnection` is used by default. In such case the slot is called from the event loop of receiver object's thread. The thread is often blocked on locking mutex resulting in event loop not spinning and deadlock.

Connection type can be changed to `Qt::DirectConnection` so the slot is called immediately from the thread that emitted the signal. It should be safe as `m_devices` is protected by a mutex already.

This PR fixes #56 and also adds missing include in `musicnoise.cpp` that prevents from successful compilation on Linux.