### PR TITLE
Removing dialogs and updating shortcut description for reset buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 *.rc
 /.qmake.cache
 /.qmake.stash
+build*
 
 # qtcreator generated files
 *.pro.user*

--- a/qml/Shortcuts.qml
+++ b/qml/Shortcuts.qml
@@ -61,7 +61,7 @@ Popup {
                     <tr><td>%1+L</td><td>append new equal Loudness contour</td></tr>
                     <tr><td>%1+F</td><td>append new filter</td></tr>
                     <tr><td>%1+X</td><td>store all measurements</td></tr>
-                    <tr><td>%1+R</td><td>reset aveverages</td></tr>
+                    <tr><td>%1+R</td><td>reset buffer</td></tr>
                     <tr><td>%1+C</td><td>store current measurement</td></tr>
                     <tr><td>%1+E</td><td>apply estimated delay for current measuremts</td></tr>
 

--- a/qml/SideBar.qml
+++ b/qml/SideBar.qml
@@ -312,21 +312,10 @@ Item {
                             rightPadding: 4
                             leftPadding: 4
                             onClicked: {
-                                applicationWindow.dialog.accepted.connect(deleteModel);
-                                applicationWindow.dialog.rejected.connect(freeDialog);
-                                applicationWindow.dialog.title = "Delete " + dragArea.source.name + "?";
-                                applicationWindow.dialog.open();
-                            }
-                            function deleteModel() {
                                 if (applicationWindow.properiesbar.currentObject === dragArea.source) {
                                     applicationWindow.properiesbar.reset();
                                 }
                                 sourceList.removeItem(dragArea.source);
-                                freeDialog();
-                            }
-                            function freeDialog() {
-                                applicationWindow.dialog.accepted.disconnect(deleteModel);
-                                applicationWindow.dialog.rejected.disconnect(freeDialog);
                             }
                             background: Rectangle {
                                 color: "transparent"

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -75,7 +75,7 @@ ApplicationWindow {
         z: -1
     }
 
-    property bool askBeforeClose : true
+    property bool askBeforeClose : false
     onClosing: function (close) {
         if (!askBeforeClose) {
             return;

--- a/qml/source/MeasurementProperties.qml
+++ b/qml/source/MeasurementProperties.qml
@@ -100,7 +100,7 @@ Item {
                 Material.background: parent.Material.background
 
                 ToolTip.visible: hovered
-                ToolTip.text: qsTr("reset buffers")
+                ToolTip.text: qsTr("reset buffer")
             }
 
             Item {


### PR DESCRIPTION
Hi,
I removed the trace remove dialog so that when some one has a lot of traces they can be removed faster.
Also I removed the quit dialog and updated the description for the shortcut to reset the buffer because it was different from the button tooltipp. 

Love the software.
With best regards
Manu