### PR TITLE
add system brightness toggle for dark mode

### DIFF
--- a/qml/Shortcuts.qml
+++ b/qml/Shortcuts.qml
@@ -79,6 +79,7 @@ Popup {
                     <tr><th colspan='2'>Tools</th></tr>
                     <tr><td>%1+W</td><td>show wavelength calculator</td></tr>
                     <tr><td>%1+D</td><td>toggle dark mode</td></tr>
+                    <tr><td>%1+Shift+D</td><td>toggle system brightness</td></tr>
                     <tr><td>F1</td><td>show keys combinations</td></tr>
                     <tr><td>F2</td><td>show info</td></tr>
                     <tr><td>F3</td><td>check for update</td></tr>

--- a/qml/menu/Top.qml
+++ b/qml/menu/Top.qml
@@ -210,11 +210,22 @@ MenuBar {
         MenuItem {
             id: darkModeSelect
             text: qsTr("&Dark Mode")
-            shortcut: "Ctrl+D"
+            shortcut: applicationAppearance.useSystemBrightness ? null : "Ctrl+D"
             checkable: true
+            visible: applicationAppearance.useSystemBrightness ? false : true
             checked: applicationAppearance.darkMode
             onCheckedChanged: {
                 applicationAppearance.darkMode = darkModeSelect.checked;
+            }
+        }
+        MenuItem {
+            id: systemBrightness
+            text: qsTr("&Use system brightness")
+            shortcut: "Ctrl+Shift+D"
+            checkable: true
+            checked: applicationAppearance.useSystemBrightness
+            onCheckedChanged: {
+                applicationAppearance.useSystemBrightness = systemBrightness.checked;
             }
         }
         MenuItem {

--- a/src/common/appearance.cpp
+++ b/src/common/appearance.cpp
@@ -43,7 +43,8 @@ bool Appearance::darkMode() const
 
 void Appearance::setDarkMode(const bool &setDark)
 {
-    if (setDark == darkMode()) {
+    if (setDark == darkMode())
+    {
         return;
     }
     auto store = settings();
@@ -51,6 +52,29 @@ void Appearance::setDarkMode(const bool &setDark)
 
     store->setValue("darkMode", setDark);
     emit darkModeChanged(setDark);
+}
+
+bool Appearance::useSystemBrightness() const
+{
+    auto store = settings();
+    Q_ASSERT(store);
+
+    auto value = store->value("useSystemBrightness");
+    return value.isValid() ? value.toBool() : true;
+}
+
+void Appearance::setUseSystemBrightness(const bool &setSystemBrightness)
+{
+    if (setSystemBrightness == useSystemBrightness())
+    {
+        return;
+    }
+    auto store = settings();
+    Q_ASSERT(store);
+
+    store->setValue("useSystemBrightness", setSystemBrightness);
+    emit useSystemBrightnessChanged(setSystemBrightness);
+    setDarkModeFromSystem();
 }
 
 bool Appearance::experimentFunctions() const
@@ -64,7 +88,8 @@ bool Appearance::experimentFunctions() const
 
 void Appearance::setExperimentFunctions(bool value)
 {
-    if (value == experimentFunctions()) {
+    if (value == experimentFunctions())
+    {
         return;
     }
     auto store = settings();
@@ -108,10 +133,13 @@ int Appearance::cursorOffset() const
 
 bool Appearance::setDarkModeFromSystem()
 {
-    bool darkMode = darkModeFromSystem();
+    if (useSystemBrightness())
+    {
+        bool darkMode = darkModeFromSystem();
 
-    setDarkMode(darkMode);
-    return darkMode;
+        setDarkMode(darkMode);
+    }
+    return darkMode();
 }
 
 Settings *Appearance::settings() const
@@ -123,5 +151,6 @@ bool Appearance::darkModeFromSystem() const
 {
     QColor middleGrey(127, 127, 127);
     auto app = qobject_cast<QGuiApplication *>(QGuiApplication::instance());
-    return middleGrey.lightnessF() > app->palette().color(QPalette::Window).lightnessF();
+    return middleGrey.lightnessF()
+        > app->palette().color(QPalette::Window).lightnessF();
 }

--- a/src/common/appearance.h
+++ b/src/common/appearance.h
@@ -25,6 +25,7 @@ class Appearance : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(bool darkMode READ darkMode WRITE setDarkMode NOTIFY darkModeChanged)
+    Q_PROPERTY(bool useSystemBrightness READ useSystemBrightness WRITE setUseSystemBrightness NOTIFY useSystemBrightnessChanged)
     Q_PROPERTY(bool showAboutOnStartup READ showAboutOnStartup CONSTANT)
     Q_PROPERTY(bool experimentFunctions READ experimentFunctions WRITE setExperimentFunctions NOTIFY
                experimentFunctionsChanged)
@@ -44,6 +45,9 @@ public:
     bool darkMode() const;
     void setDarkMode(const bool &setDark);
 
+    bool useSystemBrightness() const;
+    void setUseSystemBrightness(const bool &setSystemBrightness);
+
     bool experimentFunctions() const;
     void setExperimentFunctions(bool value);
 
@@ -58,6 +62,7 @@ public slots:
 
 signals:
     void darkModeChanged(bool);
+    void useSystemBrightnessChanged(bool);
     void experimentFunctionsChanged(bool);
     void visibilityChanged();
 


### PR DESCRIPTION
This pr adds a new toggle to use system brightness for dark mode. 

Currently the application will fallback to the system dark mode on startup, not caring for the value the user set in the previous session.

The user will have now a checkbox (on by default) to use the system dark mode or set manually dark/light mode, persisting the application restart.

This is my first time using QT so I tried to stick to the existing features as close as possible.

The idea for this feature stems from my brother and I's experience using the application on Windows 10/11 where it starts in light mode despite the system using dark mode. There is a need to look for the root cause but I do not have the necessary skills to do so.