### PR TITLE
feat: add Space as shortcut for saving measurements

### DIFF
--- a/qml/Shortcuts.qml
+++ b/qml/Shortcuts.qml
@@ -61,7 +61,7 @@ Popup {
                     <tr><td>%1+M</td><td>append new math source</td></tr>
                     <tr><td>%1+L</td><td>append new equal Loudness contour</td></tr>
                     <tr><td>%1+F</td><td>append new filter</td></tr>
-                    <tr><td>%1+X</td><td>store all measurements</td></tr>
+                    <tr><td>%1+X / Space</td><td>store all measurements</td></tr>
                     <tr><td>%1+R</td><td>reset aveverages</td></tr>
                     <tr><td>%1+C</td><td>store current measurement</td></tr>
                     <tr><td>%1+E</td><td>apply estimated delay for current measuremts</td></tr>

--- a/qml/SideBar.qml
+++ b/qml/SideBar.qml
@@ -169,7 +169,7 @@ Item {
         }
 
         Shortcut {
-            sequence: "Ctrl+X"
+            sequences: ["Ctrl+X", "Space"]
             context: Qt.ApplicationShortcut
             onActivated: {
                 for (var i = 0; i < sourceList.count; i++) {


### PR DESCRIPTION
This matches the behavior is other established software such as Smaart or RCF RDNet. 

This is a very common action and following (or at least allowing for) similar behavior as other software would improve the experience of users switching from those applications.