### PR TITLE
Add a basic build workflow to the repository.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,42 @@
+name: Build OSM
+
+on:
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-22.04
+          - ubuntu-24.04
+        arch:
+          - ""
+          - "-arm"
+
+    runs-on: ${{ matrix.os }}${{ matrix.arch }}
+
+    steps:
+      - name: Checkout the repository on the runner
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt -y upgrade
+          sudo apt -y install build-essential qt5-qmake-bin qt5-qmake libqt5opengl5-dev \
+            qtbase5-dev libqt5opengl5-dev qtquickcontrols2-5-dev qtdeclarative5-dev \
+            libasound2-dev
+
+      - name: Configure the tree with qmake
+        run: |
+          mkdir -p _build
+          cd _build
+          qmake OSM_BUILD_APPIMAGE=false ..
+          cd ..
+
+      - name: Build the source
+        run: make -C _build -j4
+

--- a/OpenSoundMeter.pro
+++ b/OpenSoundMeter.pro
@@ -7,6 +7,12 @@ CONFIG += qmltypes
 QML_IMPORT_NAME = OpenSoundMeterModule
 QML_IMPORT_MAJOR_VERSION = 1
 
+# Set this to false in the qmake command to avoid building
+# the appimage. Useful for Github workflows and Debian packaging.
+!defined(OSM_BUILD_APPIMAGE, var) {
+  OSM_BUILD_APPIMAGE = true
+}
+
 SOURCES += src/main.cpp \
     src/abstract/data.cpp \
     src/abstract/levelsdata.cpp \
@@ -522,7 +528,7 @@ isEqual(GRAPH, "OPENGL") {
 #}
 
 # Special rules for deployment on Linux for AppImage
-unix:!macx:!ios:CONFIG(release, debug|release) {
+unix:!macx:!ios:CONFIG(release, debug|release):equals(OSM_BUILD_APPIMAGE, "true") {
     QMAKE_POST_LINK += $$QMAKE_COPY $$PWD/OpenSoundMeter.desktop $$OUT_PWD/OpenSoundMeter_\\"$$APP_GIT_VERSION\\".desktop
     QMAKE_POST_LINK += && $$QMAKE_COPY $$PWD/icons/white.png $$OUT_PWD
     QMAKE_POST_LINK += && $$QMAKE_COPY $$PWD/linuxdeployosm.sh $$OUT_PWD


### PR DESCRIPTION
This workflow runs manually on branches and is required on pull-requests.

Attempt building on 22.04, 24.04 for x64 and arm to demonstrate that it isn't broken on any of those platforms.

Made the appimage build parametric so that it can be disabled during the workflow and potentially later steps that might not want the appimage.